### PR TITLE
refresh Token 보안 강화 전략 실행

### DIFF
--- a/dontgo/build.gradle
+++ b/dontgo/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	// DB
-	// runtimeOnly 'com.h2database:h2'
+ runtimeOnly 'com.h2database:h2'
 	implementation 'org.mariadb.jdbc:mariadb-java-client:2.7.3'
 	runtimeOnly 'com.mysql:mysql-connector-j' // Maria DB와 호환
 

--- a/dontgo/src/main/java/com/dontgoback/dontgo/config/oauth/OAuth2SuccessHandler.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/config/oauth/OAuth2SuccessHandler.java
@@ -48,7 +48,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         /* TokenProvider를 사용하여 리프레시 토큰을 만들고, saveRefreshToken() 메서드를 호출하여 해당 토큰을 DB에 유저 id와 함께 저장
         이후 클라이언트에서 액세스토큰이 만료되면, 재발급을 요청하도록 addRefreshTokenToCookie()를 호출해서 쿠키에 리프레시 토큰을 저장 */
         String refreshToken = tokenProvider.generateToken(user, REFRESH_TOKEN_DURATION);
-        saveRefreshToken(user.getId(), refreshToken);
+        saveRefreshToken(user, refreshToken);
         addRefreshTokenToCookie(request, response, refreshToken);
 
         /* 액세스 토큰을 클라이언트한테 전달하기
@@ -68,10 +68,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     // 생성된 리프레시 토큰을 전달받아서 DB에 저장
-    private void saveRefreshToken(Long userId, String newRefreshToken){
-        RefreshToken refreshToken = refreshTokenRepository.findByUserId(userId)
+    private void saveRefreshToken(User user, String newRefreshToken){
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getId())
                 .map(entity -> entity.update(newRefreshToken))
-                .orElse(new RefreshToken(userId, newRefreshToken));
+                .orElse(new RefreshToken(user, newRefreshToken));
 
         refreshTokenRepository.save(refreshToken);
     }
@@ -83,7 +83,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         int cookieMaxAge = (int) REFRESH_TOKEN_DURATION.toSeconds();
         CookieUtil.deleteCookie(request, response, REFRESH_TOKEN_COOKIE_NAME); // 기존 리프레시 토큰 제거 하고
         boolean httpOnly = true;
-        boolean httpsOnly = true;
+        boolean httpsOnly = false;
         CookieUtil.addCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, cookieMaxAge, httpOnly, httpsOnly); // 새로운 거 추가
     }
 

--- a/dontgo/src/main/java/com/dontgoback/dontgo/config/security/WebOAuthSecurityConfig.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/config/security/WebOAuthSecurityConfig.java
@@ -28,6 +28,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 import static com.dontgoback.dontgo.global.util.GlobalValues.FRONTEND_URL;
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 
 @RequiredArgsConstructor
@@ -41,7 +42,7 @@ public class WebOAuthSecurityConfig {
     @Bean
     public WebSecurityCustomizer configure() {     // Spring Security 기능 비활성화
         return (web) -> web.ignoring()
-
+                .requestMatchers(toH2Console())
                 .requestMatchers("/img/**", "/css/**", "/js/**");
     }
 

--- a/dontgo/src/main/java/com/dontgoback/dontgo/domain/comment/Comment.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/domain/comment/Comment.java
@@ -1,9 +1,7 @@
 package com.dontgoback.dontgo.domain.comment;
 
-//import com.dontgoback.dontgo.domain.commentLike.CommentLike;
+
 import com.dontgoback.dontgo.domain.feed.Feed;
-//import com.dontgoback.dontgo.domain.notification.Notification;
-//import com.dontgoback.dontgo.domain.user.User;
 import com.dontgoback.dontgo.domain.user.User;
 import com.dontgoback.dontgo.global.jpa.BaseEntity;
 import com.dontgoback.dontgo.global.jpa.EmbeddedTypes.RedBlueType;
@@ -12,7 +10,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
-import java.util.List;
+
 
 import static com.dontgoback.dontgo.global.util.GlobalValues.MAX_TEXT_LENGTH;
 

--- a/dontgo/src/main/java/com/dontgoback/dontgo/domain/feed/Feed.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/domain/feed/Feed.java
@@ -26,9 +26,6 @@ public class Feed extends BaseEntity {
     @JoinColumn(name = "USER_ID")
     private User user;
 
-    @OneToMany(mappedBy = "feed")
-    private List<Comment> comment;
-
     // 유저 이름(userAsset)이 매일 갱신되니까, 게시글은 이를 갖고 있어야함
     @Column(nullable = false)
     private String author;

--- a/dontgo/src/main/java/com/dontgoback/dontgo/domain/refreshToken/RefreshToken.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/domain/refreshToken/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.dontgoback.dontgo.domain.refreshToken;
 
+import com.dontgoback.dontgo.domain.user.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,14 +24,15 @@ public class RefreshToken {
     @Column(name = "id", updatable = false)
     private Long id;
 
-    @Column(name = "user_id", nullable = false, unique = true)
-    private Long userId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
 
     @Column(name = "refresh_token", nullable = false)
     private String refreshToken;
 
-    public RefreshToken(Long userId, String refreshToken){
-        this.userId = userId;
+    public RefreshToken(User user, String refreshToken){
+        this.user = user;
         this.refreshToken = refreshToken;
     }
 
@@ -38,5 +40,4 @@ public class RefreshToken {
         this.refreshToken = newRefreshToken;
         return this;
     }
-
 }

--- a/dontgo/src/main/java/com/dontgoback/dontgo/domain/refreshToken/TokenApiController.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/domain/refreshToken/TokenApiController.java
@@ -5,9 +5,7 @@ import com.dontgoback.dontgo.domain.refreshToken.dto.CreateAccessTokenResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -15,10 +13,14 @@ public class TokenApiController {
     private final TokenService tokenService;
 
     // Post 요청이 오면, 리프레시 토큰을 기반으로 새로운 액세스 토큰을 생성해서 반환해줌.
-    @PostMapping("/api/token")
+    @GetMapping("/api/token")
     public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken
-            (@RequestBody CreateAccessTokenRequest request){
-        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+            (@CookieValue(name = "refresh_token", required = false) String refreshToken){
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String newAccessToken = tokenService.createNewAccessToken(refreshToken);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new CreateAccessTokenResponse(newAccessToken));

--- a/dontgo/src/main/java/com/dontgoback/dontgo/domain/refreshToken/TokenService.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/domain/refreshToken/TokenService.java
@@ -22,8 +22,8 @@ public class TokenService {
             throw new IllegalArgumentException("Unexpect refreshToken token");
         }
 
-        Long userId = refreshTokenService.findByRefreshToken(refreshToken).getUserId();
-        User user = userService.findById(userId);
+        RefreshToken refreshTokenObj = refreshTokenService.findByRefreshToken(refreshToken);
+        User user = refreshTokenObj.getUser();
 
         // 두시간짜리 액세스 토큰 발급
         return tokenProvider.generateToken(user, Duration.ofHours(2));

--- a/dontgo/src/main/java/com/dontgoback/dontgo/global/util/GlobalValues.java
+++ b/dontgo/src/main/java/com/dontgoback/dontgo/global/util/GlobalValues.java
@@ -11,10 +11,10 @@ public class GlobalValues {
     public static final String REFRESH_TOKEN_NAME = "refresh_token";
 
     // dev 환경
-    // public static final String FRONTEND_URL = "http://localhost:3000";
-    // public static final String BACKEND_API_URL = "http://localhost:8090/api";
+     public static final String FRONTEND_URL = "http://localhost:3000";
+     public static final String BACKEND_API_URL = "http://localhost:8090/api";
 
     // prod 환경
-   public static final String FRONTEND_URL = "https://dontgoback.kro.kr";
-   public static final String BACKEND_API_URL = "https://dontgoback.kro.kr/api";
+//   public static final String FRONTEND_URL = "https://dontgoback.kro.kr";
+//   public static final String BACKEND_API_URL = "https://dontgoback.kro.kr/api";
    }

--- a/dontgo/src/main/resources/application-dev.yml
+++ b/dontgo/src/main/resources/application-dev.yml
@@ -15,8 +15,18 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+  jpa:
+    show-sql: true                      # 콘솔에 SQL 출력
+    properties:
+      hibernate:
+        format_sql: true                # SQL 보기 좋게 출력
+        use_sql_comments: true          # 주석 포함 (optional)
 
-
+logging:
+  level:
+    org.springframework.jdbc: DEBUG
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type: TRACE
 
 # datasource:
 #  driver-class-name: com.mysql.cj.jdbc.Driver

--- a/dontgo/src/main/resources/application.yml
+++ b/dontgo/src/main/resources/application.yml
@@ -1,4 +1,4 @@
 spring:
   profiles:
-    active: test
+    active: dev
     include: secret

--- a/frontend_v2/src/app/(layout)/utils/httpRequest.tsx
+++ b/frontend_v2/src/app/(layout)/utils/httpRequest.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { ACCESS_TOKEN_NAME, BACKEND_API_URL, REFRESH_TOKEN_NAME } from "./values";
+import { ACCESS_TOKEN_NAME, BACKEND_API_URL } from "./values";
 
 // 쿠키에서 값 가져오기 함수
 export function getCookie(name: string) {
@@ -19,7 +19,7 @@ const isNotFound = (status: number) => status === 404; // 리소스 없음
 
 // 토큰 관리 유틸리티
 const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_NAME);
-const getRefreshToken = () => getCookie(REFRESH_TOKEN_NAME);
+// const getRefreshToken = () => getCookie(REFRESH_TOKEN_NAME);
 const setAccessToken = (token: string) => localStorage.setItem(ACCESS_TOKEN_NAME, token);
 const redirectToLogin = () => window.location.replace("/login");
 
@@ -46,13 +46,13 @@ const handleErrorResponse = async (response: Response, fail: () => void) => {
 };
 
 // 토큰 갱신 관련 로직
-const refreshAccessToken = async (refreshToken: string) => {
+const refreshAccessToken = async () => {
   console.log("🔄 액세스 토큰 갱신 시도");
 
   const response = await fetch(`${BACKEND_API_URL}/token`, {
-    method: "POST",
+    method: "GET",
+    credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ refreshToken }),
   });
 
   if (!response.ok) {
@@ -81,16 +81,16 @@ const handleUnauthorizedError = async (
   success: (result: any) => void,
   fail: () => void
 ) => {
-  const refreshToken = getRefreshToken();
-  if (!refreshToken) {
-    console.error("❌ Refresh Token 없음");
-    redirectToLogin();
-    fail();
-    return;
-  }
+  // const refreshToken = getRefreshToken();
+  // if (!refreshToken) {
+  //   console.error("❌ Refresh Token 없음");
+  //   redirectToLogin();
+  //   fail();
+  //   return;
+  // }
 
   try {
-    const { accessToken } = await refreshAccessToken(refreshToken);
+    const { accessToken } = await refreshAccessToken();
     setAccessToken(accessToken);
     console.log("🔑 새 액세스 토큰 발급 완료");
     retryOriginalRequest(method, url, body, success, fail);
@@ -112,7 +112,6 @@ export async function httpRequest(
   try {
     const response = await fetch(url, {
       method,
-      credentials: "include",
       headers: {
         Authorization: `Bearer ${getAccessToken()}`,
         "Content-Type": "application/json",

--- a/frontend_v2/src/app/(layout)/utils/values.tsx
+++ b/frontend_v2/src/app/(layout)/utils/values.tsx
@@ -6,11 +6,11 @@ export const ACCESS_TOKEN_FOR_VISITER =
   "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NDE1OTg4MTcsImV4cCI6MTc0MTY4NTIxNywic3ViIjoiMTIzcWtyZ2hkdGpyQGdtYWlsLmNvbSIsImlkIjoxfQ.URrRvXaSXjJKt1m8ny5Qh_mQ3GSKc9KlgsZdJc8Y16M";
 
 // 로컬
-// export const FRONTEND_URL = "http://localhost:3000";
-// export const BACKEND_API_URL = "http://localhost:8090/api";
+export const FRONTEND_URL = "http://localhost:3000";
+export const BACKEND_API_URL = "http://localhost:8090/api";
 
 // 배포 EC2
-export const FRONTEND_URL = "https://dontgoback.kro.kr";
-export const BACKEND_API_URL = "https://dontgoback.kro.kr/api";
+// export const FRONTEND_URL = "https://dontgoback.kro.kr";
+// export const BACKEND_API_URL = "https://dontgoback.kro.kr/api";
 
 // // 배포 라즈베리파이


### PR DESCRIPTION
1. refreshToken을 사용자 브라우저에서 POST 요청으로 body에 담아 보내는 문제 개선
- 서버에서 쿠키 발급 시 http Only 옵션 사용으로 변경
- 클라이언트 측, GET 요청으로 변경
- 서버 측, 컨트롤러에서 GetMapping과, requestBady가 아닌 쿠키로부터 refreshToken 얻도록, Null가능하게 설정(400에러 방지)
(개발 환경에서 https false 로 바꾼 상황)

