### PR TITLE
jvm timezone 미설정 문제 (slim버전 사용으로 인한 시간 계산(UTC) 누락 추정

### DIFF
--- a/dontgo/Dockerfile
+++ b/dontgo/Dockerfile
@@ -16,6 +16,12 @@ EXPOSE 8090
 # 2단계: 실행 환경 설정
 FROM openjdk:21-jdk-slim
 
+# 타임존 설정 추가 (slim에는 시간 관련 table이 빠져있어서, 계산 불가하기에 tzdata 설치 요망)
+ENV TZ=Asia/Seoul
+RUN apt-get update && apt-get install -y tzdata && \
+    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # 작업 디렉토리 설정
 WORKDIR /app
 
@@ -26,5 +32,6 @@ COPY --from=build /app/build/libs/dontgo-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8090
 
 # 서버 실행
-CMD ["sh", "-c", "sleep 10 && java -jar app.jar"]
+CMD ["sh", "-c", "sleep 10 && java -Duser.timezone=Asia/Seoul -jar app.jar"]
+# CMD ["sh", "-c", "sleep 10 && java -jar app.jar"]
 # CMD ["java", "-jar", "app.jar"]

--- a/dontgo/src/main/resources/application.yml
+++ b/dontgo/src/main/resources/application.yml
@@ -2,3 +2,5 @@ spring:
   profiles:
     active: dev
     include: secret
+  jackson: # JSON 직렬화/역직렬화 시점의 시간대 설정
+    time-zone: Asia/Seoul


### PR DESCRIPTION
# Dockerfile에 tzdata설치 및 Timezone 설정 추가
 - tzdata는 시간대 설정 시 실제 시간대 파일을 제공해주는 핵심 패키지
- 타임존 설정 추가 (slim에는 시간 관련 table이 빠져있어서, 계산 불가하기에 tzdata 설치 요망)

ENV TZ=Asia/Seoul
RUN apt-get update && apt-get install -y tzdata && \
    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
    apt-get clean && rm -rf /var/lib/apt/lists/*
