### PR TITLE
Principal & Token 개선

### DIFF
--- a/dontgo/src/test/java/com/dontgoback/dontgo/domain/feed/ApiV1FeedControllerTest.java
+++ b/dontgo/src/test/java/com/dontgoback/dontgo/domain/feed/ApiV1FeedControllerTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class ApiV1FeedControllerTest {
+  
+}

--- a/frontend_v2/src/app/(layout)/utils/globalValues.tsx
+++ b/frontend_v2/src/app/(layout)/utils/globalValues.tsx
@@ -2,9 +2,7 @@ export const MAX_TEXT_LENGTH = 500;
 export const ACCESS_TOKEN_NAME = "access_token";
 export const REFRESH_TOKEN_NAME = "refresh_token";
 
-export const ACCESS_TOKEN_FOR_VISITER =
-  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3NDE1OTg4MTcsImV4cCI6MTc0MTY4NTIxNywic3ViIjoiMTIzcWtyZ2hkdGpyQGdtYWlsLmNvbSIsImlkIjoxfQ.URrRvXaSXjJKt1m8ny5Qh_mQ3GSKc9KlgsZdJc8Y16M";
-
+export const ACCESS_TOKEN_FOR_VISITER = process.env.NEXT_PUBLIC_JWT;
 // 로컬
 export const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL!;
 export const BACKEND_API_URL = process.env.NEXT_PUBLIC_BACKEND_API_URL!;


### PR DESCRIPTION
1. 우선 기존의 jwt의 내부엔 유저의 id와 email이 존재 
2. 하지만 userDetials를 상속받은 user 엔티티가 있음에도 불구하고, 단순 기본 제공 인증 객체를 authentication 객체에 주입
3. 따라서 principal 객체 내에 email값만 존재 
4. 따라서 id값과 email 값을 포함한 정보를 기반으로 내가 작성 한 user 엔티티를 생성 후 (다른 정보 없음) 인증 객체에 주입
5. 따라서 기존엔 email을 꺼내서, 이를통해 유저를 조회 후 id를 꺼내야했지만, 이젠 곧바로 인증 객체에서 userID를 꺼낼 수 있음
6. (DB에서 유저를 조회하는 일 한 번 감소
7. 하지만 개시글/답글의 생성 기능은, DTO에 유저의 타입 등 매일 갱신되는 정보를 넣어야하므로, 토큰 파싱으로부터 생성되는 User 객체에 id와 email 이외의 값을 넣어서 인증 객체를 생성하기엔 데이터 무결성 문제에 문제 예상
8. 따라서, 생성의 경우엔 db에서 최신 정보 조회
+ 
4월 24일까지 유지되는 jwt 발급 후 방문자용으로 사용