### PR TITLE
방문자 토큰 추가 시 인증 과정에서 토큰 소실 문제 해결

### DIFF
--- a/frontend_v2/src/app/(layout)/contexts/UserContext.tsx
+++ b/frontend_v2/src/app/(layout)/contexts/UserContext.tsx
@@ -2,7 +2,7 @@ import { useRouter } from "next/navigation";
 import { httpRequest } from "../utils/httpRequest";
 import * as Types from "../utils/types";
 import React, { createContext, useState, useContext, ReactNode } from "react";
-import { ACCESS_TOKEN_NAME, BACKEND_API_URL } from "../utils/globalValues";
+import { BACKEND_API_URL } from "../utils/globalValues";
 
 interface UserContextType {
   userContext: Types.User | null;
@@ -24,7 +24,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     };
     const fail = () => {
       console.warn("[fetchUserContext] 유저 로딩 실패 함수 호출");
-      localStorage.setItem(`${ACCESS_TOKEN_NAME}`, "");
+      // localStorage.setItem(`${ACCESS_TOKEN_NAME}`, "");
       // console.error("토큰 초기화 및 재로그인");
       router.replace("/login"); // 뒤로가기 방지 이동
     };


### PR DESCRIPTION
프론트부분 userContext에서 인증 실패 시, access token 의 값을 지우는 부분을 일시적으로 비활성화
- 방문자에 대한 접근 방식의 근본적인 개선이 필요할듯
